### PR TITLE
Some refactors to simplify PullHandler

### DIFF
--- a/bin/local_test
+++ b/bin/local_test
@@ -3,7 +3,7 @@ require File.expand_path('../../test/test_helper', __FILE__)
 
 require 'ladle'
 
-require 'ladle/pull_handler'
+require 'ladle/pull_request_change_collector'
 require 'ladle/local_repository_client'
 
 class LocalRepoTest < ActiveSupport::TestCase
@@ -16,10 +16,10 @@ class LocalRepoTest < ActiveSupport::TestCase
                                               base_ref: 'dbe4952c800c9d50fb61e68d883765d907995200',
                                               head_ref: '6d6ebd991450ea1a95ca431ec5cd60764d99ef24')
 
-    pull_handler = Ladle::PullHandler.new(client)
+    collector = Ladle::PullRequestChangeCollector.new(client)
 
     ActionMailer::Base.logger = ::Logger.new(STDOUT)
-    pp pull_handler.handle(pull_request)
+    pp collector.collect_changes(pull_request)
   end
 end
 

--- a/bin/local_test
+++ b/bin/local_test
@@ -4,7 +4,6 @@ require File.expand_path('../../test/test_helper', __FILE__)
 require 'ladle'
 
 require 'ladle/pull_handler'
-require 'ladle/steward_notifier'
 require 'ladle/local_repository_client'
 
 class LocalRepoTest < ActiveSupport::TestCase
@@ -17,12 +16,10 @@ class LocalRepoTest < ActiveSupport::TestCase
                                               base_ref: 'dbe4952c800c9d50fb61e68d883765d907995200',
                                               head_ref: '6d6ebd991450ea1a95ca431ec5cd60764d99ef24')
 
-    notifier = Ladle::StewardNotifier.new("ladle-stage", pull_request)
-
-    pull_handler = Ladle::PullHandler.new(client, notifier)
+    pull_handler = Ladle::PullHandler.new(client)
 
     ActionMailer::Base.logger = ::Logger.new(STDOUT)
-    pull_handler.handle(pull_request)
+    pp pull_handler.handle(pull_request)
   end
 end
 

--- a/development.md
+++ b/development.md
@@ -33,5 +33,5 @@ You can test the application against a remote repository on Github using the fol
 You can test the handling of PRs using a local repository on the file system using `Ladle::LocalRepositoryClient`:
 
 1. Setup a local repository with scenarios you would like to test.
-2. Create a `Ladle::LocalRepositoryClient` and run it through `Ladle::PullHandler`.
+2. Create a `Ladle::LocalRepositoryClient` and run it through `Ladle::PullRequestChangeCollector`.
 3. See [bin/local_test](bin/local_test) for an example.

--- a/lib/ladle/notify_stewards_of_pull_request_changes.rb
+++ b/lib/ladle/notify_stewards_of_pull_request_changes.rb
@@ -1,0 +1,23 @@
+require 'ladle/github_repository_client'
+require 'ladle/pull_handler'
+require 'ladle/steward_notifier'
+
+module Ladle
+  class NotifyStewardsOfPullRequestChanges
+
+    def self.call(pull_request)
+      github_client = Ladle::GithubRepositoryClient.new(pull_request.repository)
+      pull_handler = Ladle::PullHandler.new(github_client)
+
+      stewards_registry = pull_handler.handle(pull_request)
+
+      if stewards_registry.empty?
+        Rails.logger.info('No stewards found. Doing nothing.')
+      else
+        Rails.logger.info("Found #{stewards_registry.size} stewards. Notifying.")
+        notifier = Ladle::StewardNotifier.new(pull_request.repository.name, pull_request)
+        notifier.notify(stewards_registry)
+      end
+    end
+  end
+end

--- a/lib/ladle/pull_handler.rb
+++ b/lib/ladle/pull_handler.rb
@@ -4,9 +4,8 @@ require 'ladle/steward_tree'
 
 module Ladle
   class PullHandler
-    def initialize(client, notifier)
+    def initialize(client)
       @client = client
-      @notifier = notifier
     end
 
     def handle(pull_request)
@@ -16,14 +15,7 @@ module Ladle
 
       stewards_trees = collect_stewards_rules(pr_info, pr_files)
 
-      stewards_registry = collect_changes(stewards_trees, pr_files)
-
-      if stewards_registry.empty?
-        Rails.logger.info('No stewards found. Doing nothing.')
-      else
-        Rails.logger.info("Found #{stewards_registry.size} stewards. Notifying.")
-        @notifier.notify(stewards_registry)
-      end
+      collect_changes(stewards_trees, pr_files)
     end
 
     private

--- a/lib/ladle/pull_request_change_collector.rb
+++ b/lib/ladle/pull_request_change_collector.rb
@@ -3,19 +3,19 @@ require 'ladle/steward_rules'
 require 'ladle/steward_tree'
 
 module Ladle
-  class PullHandler
+  class PullRequestChangeCollector
     def initialize(client)
       @client = client
     end
 
-    def handle(pull_request)
+    def collect_changes(pull_request)
       pr_info = @client.pull_request(pull_request.number)
 
       pr_files = @client.pull_request_files(pull_request.number)
 
       stewards_trees = collect_stewards_rules(pr_info, pr_files)
 
-      collect_changes(stewards_trees, pr_files)
+      append_changes(stewards_trees, pr_files)
     end
 
     private
@@ -54,7 +54,7 @@ module Ladle
       Rails.logger.error("Error parsing file #{stewards_file_path}: #{e.message}\n#{e.backtrace.join("\n")}")
     end
 
-    def collect_changes(stewards_trees, pull_request_files)
+    def append_changes(stewards_trees, pull_request_files)
       output = {}
 
       stewards_trees.each do |github_username, steward_tree|

--- a/lib/ladle/test_data.rb
+++ b/lib/ladle/test_data.rb
@@ -29,5 +29,13 @@ module Ladle
         }
       )
     end
+
+    def self.create_stewards_map
+      {
+        'xanderstrike' => create_changes_view,
+        'counterstrike'=> create_changes_view,
+        'boop'         => create_changes_view
+      }
+    end
   end
 end

--- a/test/assert_deep_hash.rb
+++ b/test/assert_deep_hash.rb
@@ -1,0 +1,24 @@
+require 'hashdiff'
+require 'erb'
+
+module AssertDeepHash
+
+  def assert_deep_hash(expected, actual, msg = nil)
+    differences = HashDiff.diff(expected, actual)
+
+    msg = message(msg) do
+      hash_diff = diff(expected, actual)
+      rb_balls = ERB.new(<<-ERB)
+        #{hash_diff}
+        Differences:
+          <% differences.each do |difference| %>
+          <%= difference.inspect %>
+          <% end %>
+      ERB
+
+      rb_balls.result(binding)
+    end
+
+    assert differences == [], msg
+  end
+end

--- a/test/controllers/github_events_controller_test.rb
+++ b/test/controllers/github_events_controller_test.rb
@@ -1,4 +1,6 @@
 require 'test_helper'
+
+require 'ladle/notify_stewards_of_pull_request_changes'
 require 'ladle/test_data'
 
 class GithubEventsControllerTest < ActionController::TestCase
@@ -6,7 +8,7 @@ class GithubEventsControllerTest < ActionController::TestCase
   test "payloads with invalid signatures are processed" do
     repository = create_repository
 
-    Ladle::PullHandler.any_instance.expects(:handle).returns({})
+    Ladle::NotifyStewardsOfPullRequestChanges.expects(:call)
 
     payload = {}.to_json
     signature = repository.compute_webhook_signature(payload)
@@ -53,51 +55,22 @@ class GithubEventsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test 'open pull request is handled and stewards are notified' do
+  test 'open pull request is handled' do
     repository = create_repository
-
-    stewards_map = Ladle::TestData.create_stewards_map
-
-    Ladle::PullHandler.any_instance.expects(:handle).with(all_of(
-                                         is_a(PullRequest),
-                                         responds_with(:number, 5),
-                                         responds_with(:html_url, 'www.test.com'),
-                                         responds_with(:title, 'Hello Dude'),
-                                         responds_with(:body, "We did it!"),
-                                       )).returns(stewards_map)
-
-    Ladle::StewardNotifier.any_instance.expects(:notify).with(stewards_map)
 
     @controller.expects(:verify_signature)
 
-    assert_difference('PullRequest.count') do
-      post :payload, {}.to_json,
-           format:       :json,
-           number:       5,
-           pull_request: {
-             state:    'open',
-             html_url: 'www.test.com',
-             title:    'Hello Dude',
-             body:     "We did it!"
-           },
-           repository:   {full_name: repository.name}
-    end
-
-    assert_response :success
-  end
-
-  test "open pull request is handled but doesn't notify if there are no stewards" do
-    repository = create_repository
-
-    Ladle::PullHandler.any_instance.expects(:handle).returns({})
-    Ladle::StewardNotifier.any_instance.expects(:notify).never
-
-    @controller.expects(:verify_signature)
-
-    Rails.logger.expects(:info).with("New pull #5 for #{repository.name}. Running handler...")
-    Rails.logger.expects(:info).with('No stewards found. Doing nothing.')
+    Ladle::NotifyStewardsOfPullRequestChanges.expects(:call).with(all_of(
+                                                                    is_a(PullRequest),
+                                                                    responds_with(:number, 5),
+                                                                    responds_with(:html_url, 'www.test.com'),
+                                                                    responds_with(:title, 'Hello Dude'),
+                                                                    responds_with(:body, "We did it!"),
+                                                                  ))
 
     assert_difference('PullRequest.count') do
+      Rails.logger.expects(:info).with("New pull #5 for #{repository.name}. Running handler...")
+
       post :payload, {}.to_json,
            format:       :json,
            number:       5,
@@ -120,7 +93,11 @@ class GithubEventsControllerTest < ActionController::TestCase
     signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), repository.webhook_secret, payload)
     request.headers['HTTP_X_HUB_SIGNATURE'] = signature
 
-    Ladle::PullHandler.expects(:new).never
+    Ladle::NotifyStewardsOfPullRequestChanges.expects(:call).never
+
+    Rails.logger.expects(:info).with("New pull #5 for #{repository.name}. Running handler...")
+    Rails.logger.expects(:info).with('Pull closed, doing nothing.')
+
     assert_no_difference('PullRequest.count') do
       post :payload, payload, format: :json, number: 5, pull_request: { state: 'closed' }, repository: { full_name: repository.name }
     end
@@ -133,7 +110,7 @@ class GithubEventsControllerTest < ActionController::TestCase
 
     pull_request = create(:pull_request, repository: repository, number: 5, body: "old description", title: "old title")
 
-    Ladle::PullHandler.any_instance.expects(:handle).returns({})
+    Ladle::NotifyStewardsOfPullRequestChanges.expects(:call)
 
     @controller.expects(:verify_signature)
 

--- a/test/ladle/github_repository_client_test.rb
+++ b/test/ladle/github_repository_client_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 require 'ladle/github_repository_client'
-require 'ladle/pull_handler'
+require 'ladle/pull_request_change_collector'
 
 class GithubRepositoryClientTest < ActiveSupport::TestCase
 
@@ -66,7 +66,7 @@ class GithubRepositoryClientTest < ActiveSupport::TestCase
     assert_equal Octokit::NotFound, raised.cause.class
   end
 
-  test "works with PullHandler" do
+  test "works with PullRequestChangeCollector" do
     expected_result = {
       head: {
         sha: 'branch_head'
@@ -100,10 +100,10 @@ class GithubRepositoryClientTest < ActiveSupport::TestCase
       .with(@repository.name, path: 'stewards.yml', ref: 'base_head')
       .raises(Octokit::NotFound)
 
-    handler = Ladle::PullHandler.new(@client)
+    collector = Ladle::PullRequestChangeCollector.new(@client)
 
     pull_request = create(:pull_request, repository: @repository, number: 12)
-    handler.handle(pull_request)
+    collector.collect_changes(pull_request)
   end
 
   private

--- a/test/ladle/github_repository_client_test.rb
+++ b/test/ladle/github_repository_client_test.rb
@@ -100,10 +100,7 @@ class GithubRepositoryClientTest < ActiveSupport::TestCase
       .with(@repository.name, path: 'stewards.yml', ref: 'base_head')
       .raises(Octokit::NotFound)
 
-    notifier = mock
-    notifier.expects(:notify)
-
-    handler = Ladle::PullHandler.new(@client, notifier)
+    handler = Ladle::PullHandler.new(@client)
 
     pull_request = create(:pull_request, repository: @repository, number: 12)
     handler.handle(pull_request)

--- a/test/ladle/github_repository_client_test.rb
+++ b/test/ladle/github_repository_client_test.rb
@@ -79,8 +79,6 @@ class GithubRepositoryClientTest < ActiveSupport::TestCase
     octokit_client = Octokit::Client.any_instance
     octokit_client.expects(:pull_request).with(@repository.name, 12).returns(expected_result)
 
-    handler_state = states('handler_state').starts_as('finding_files')
-
     expected_result = [
       {status: "added", filename: 'one.rb'},
       {status: "modified", filename: 'sub/marine.rb'},

--- a/test/ladle/local_repository_client_test.rb
+++ b/test/ladle/local_repository_client_test.rb
@@ -107,10 +107,7 @@ class LocalRepositoryClientTest < ActiveSupport::TestCase
     rugged_client.expects(:lookup).with("base_head").when(handler_state.is('finding_content')).in_sequence(content_sequence).returns(mock('commit', tree: tree))
     rugged_client.expects(:lookup).with('object_id').returns(mock(content: content))
 
-    notifier = mock
-    notifier.expects(:notify)
-
-    handler = Ladle::PullHandler.new(@client, notifier)
+    handler = Ladle::PullHandler.new(@client)
 
     pull_request = create(:pull_request, repository: @repository)
     handler.handle(pull_request)

--- a/test/ladle/local_repository_client_test.rb
+++ b/test/ladle/local_repository_client_test.rb
@@ -79,7 +79,7 @@ class LocalRepositoryClientTest < ActiveSupport::TestCase
   end
 
   test "works with PullRequestChangeCollector" do
-    handler_state = states('handler_state').starts_as('finding_files')
+    collector_state = states('collector_state').starts_as('finding_files')
 
     deltas = [
       mock(status: :added, new_file: {path: "one.rb"}),
@@ -89,9 +89,9 @@ class LocalRepositoryClientTest < ActiveSupport::TestCase
     commit = mock
 
     rugged_client = Rugged::Repository.any_instance
-    rugged_client.expects(:lookup).with("base_head").when(handler_state.is('finding_files')).returns(commit)
+    rugged_client.expects(:lookup).with("base_head").when(collector_state.is('finding_files')).returns(commit)
 
-    commit.expects(:diff).with('branch_head').returns(mock(deltas: deltas)).when(handler_state.is('finding_files')).then(handler_state.is('finding_content'))
+    commit.expects(:diff).with('branch_head').returns(mock(deltas: deltas)).when(collector_state.is('finding_files')).then(collector_state.is('finding_content'))
 
     content = <<-YAML
       stewards:
@@ -103,8 +103,8 @@ class LocalRepositoryClientTest < ActiveSupport::TestCase
     tree.expects(:walk_blobs).twice.multiple_yields(["",{name: "some_file.bleh"}], ["sub", {name: "stewards.yml", oid: "object_id"}])
 
     content_sequence = sequence('content')
-    rugged_client.expects(:lookup).with("base_head").when(handler_state.is('finding_content')).in_sequence(content_sequence).returns(mock('commit', tree: tree))
-    rugged_client.expects(:lookup).with("base_head").when(handler_state.is('finding_content')).in_sequence(content_sequence).returns(mock('commit', tree: tree))
+    rugged_client.expects(:lookup).with("base_head").when(collector_state.is('finding_content')).in_sequence(content_sequence).returns(mock('commit', tree: tree))
+    rugged_client.expects(:lookup).with("base_head").when(collector_state.is('finding_content')).in_sequence(content_sequence).returns(mock('commit', tree: tree))
     rugged_client.expects(:lookup).with('object_id').returns(mock(content: content))
 
     collector = Ladle::PullRequestChangeCollector.new(@client)

--- a/test/ladle/local_repository_client_test.rb
+++ b/test/ladle/local_repository_client_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 require 'ladle/local_repository_client'
-require 'ladle/pull_handler'
+require 'ladle/pull_request_change_collector'
 
 class LocalRepositoryClientTest < ActiveSupport::TestCase
 
@@ -78,7 +78,7 @@ class LocalRepositoryClientTest < ActiveSupport::TestCase
     assert_equal "No support for status :what", raised.message
   end
 
-  test "works with PullHandler" do
+  test "works with PullRequestChangeCollector" do
     handler_state = states('handler_state').starts_as('finding_files')
 
     deltas = [
@@ -107,9 +107,9 @@ class LocalRepositoryClientTest < ActiveSupport::TestCase
     rugged_client.expects(:lookup).with("base_head").when(handler_state.is('finding_content')).in_sequence(content_sequence).returns(mock('commit', tree: tree))
     rugged_client.expects(:lookup).with('object_id').returns(mock(content: content))
 
-    handler = Ladle::PullHandler.new(@client)
+    collector = Ladle::PullRequestChangeCollector.new(@client)
 
     pull_request = create(:pull_request, repository: @repository)
-    handler.handle(pull_request)
+    collector.collect_changes(pull_request)
   end
 end

--- a/test/ladle/notify_stewards_of_pull_request_changes_test.rb
+++ b/test/ladle/notify_stewards_of_pull_request_changes_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+require 'ladle/notify_stewards_of_pull_request_changes'
+require 'ladle/github_repository_client'
+require 'ladle/test_data'
+
+class NotifyStewardsOfPullRequestChangesTest < ActiveSupport::TestCase
+
+  setup do
+    @pull_request = create(:pull_request)
+  end
+
+  test "PullHandler uses github client" do
+    handler_mock = mock
+    handler_mock.expects(:handle).returns({})
+
+    Ladle::PullHandler.expects(:new).with(is_a(Ladle::GithubRepositoryClient)).returns(handler_mock)
+
+    Ladle::NotifyStewardsOfPullRequestChanges.call(@pull_request)
+  end
+
+  test 'open pull request is handled and stewards are notified' do
+    stewards_map = Ladle::TestData.create_stewards_map
+
+    Ladle::PullHandler.any_instance.expects(:handle).with(@pull_request).returns(stewards_map)
+    Ladle::StewardNotifier.any_instance.expects(:notify).with(stewards_map)
+
+    Rails.logger.expects(:info).with("Found #{stewards_map.size} stewards. Notifying.")
+
+    Ladle::NotifyStewardsOfPullRequestChanges.call(@pull_request)
+  end
+
+  test "open pull request is handled but doesn't notify if there are no stewards" do
+    Ladle::PullHandler.any_instance.expects(:handle).returns({})
+    Ladle::StewardNotifier.any_instance.expects(:notify).never
+
+    Rails.logger.expects(:info).with('No stewards found. Doing nothing.')
+
+    Ladle::NotifyStewardsOfPullRequestChanges.call(@pull_request)
+  end
+end

--- a/test/ladle/notify_stewards_of_pull_request_changes_test.rb
+++ b/test/ladle/notify_stewards_of_pull_request_changes_test.rb
@@ -18,7 +18,7 @@ class NotifyStewardsOfPullRequestChangesTest < ActiveSupport::TestCase
     Ladle::NotifyStewardsOfPullRequestChanges.call(@pull_request)
   end
 
-  test 'open pull request is handled and stewards are notified' do
+  test 'stewards are notified when there are changes' do
     stewards_map = Ladle::TestData.create_stewards_map
 
     Ladle::PullRequestChangeCollector.any_instance.expects(:collect_changes).with(@pull_request).returns(stewards_map)
@@ -29,7 +29,7 @@ class NotifyStewardsOfPullRequestChangesTest < ActiveSupport::TestCase
     Ladle::NotifyStewardsOfPullRequestChanges.call(@pull_request)
   end
 
-  test "open pull request is handled but doesn't notify if there are no stewards" do
+  test "stewards are not notified when there are not changes" do
     Ladle::PullRequestChangeCollector.any_instance.expects(:collect_changes).returns({})
     Ladle::StewardNotifier.any_instance.expects(:notify).never
 

--- a/test/ladle/notify_stewards_of_pull_request_changes_test.rb
+++ b/test/ladle/notify_stewards_of_pull_request_changes_test.rb
@@ -9,11 +9,11 @@ class NotifyStewardsOfPullRequestChangesTest < ActiveSupport::TestCase
     @pull_request = create(:pull_request)
   end
 
-  test "PullHandler uses github client" do
-    handler_mock = mock
-    handler_mock.expects(:handle).returns({})
+  test "PullRequestChangeCollector uses github client" do
+    collector_mock = mock
+    collector_mock.expects(:collect_changes).returns({})
 
-    Ladle::PullHandler.expects(:new).with(is_a(Ladle::GithubRepositoryClient)).returns(handler_mock)
+    Ladle::PullRequestChangeCollector.expects(:new).with(is_a(Ladle::GithubRepositoryClient)).returns(collector_mock)
 
     Ladle::NotifyStewardsOfPullRequestChanges.call(@pull_request)
   end
@@ -21,7 +21,7 @@ class NotifyStewardsOfPullRequestChangesTest < ActiveSupport::TestCase
   test 'open pull request is handled and stewards are notified' do
     stewards_map = Ladle::TestData.create_stewards_map
 
-    Ladle::PullHandler.any_instance.expects(:handle).with(@pull_request).returns(stewards_map)
+    Ladle::PullRequestChangeCollector.any_instance.expects(:collect_changes).with(@pull_request).returns(stewards_map)
     Ladle::StewardNotifier.any_instance.expects(:notify).with(stewards_map)
 
     Rails.logger.expects(:info).with("Found #{stewards_map.size} stewards. Notifying.")
@@ -30,7 +30,7 @@ class NotifyStewardsOfPullRequestChangesTest < ActiveSupport::TestCase
   end
 
   test "open pull request is handled but doesn't notify if there are no stewards" do
-    Ladle::PullHandler.any_instance.expects(:handle).returns({})
+    Ladle::PullRequestChangeCollector.any_instance.expects(:collect_changes).returns({})
     Ladle::StewardNotifier.any_instance.expects(:notify).never
 
     Rails.logger.expects(:info).with('No stewards found. Doing nothing.')

--- a/test/ladle/pull_request_change_collector_test.rb
+++ b/test/ladle/pull_request_change_collector_test.rb
@@ -30,7 +30,7 @@ class PullRequestChangeCollectorTest < ActiveSupport::TestCase
     assert_equal({}, Ladle::PullRequestChangeCollector.new(client).collect_changes(@pull_request))
   end
 
-  test 'notifies stewards' do
+  test "collects stewards across stewards files" do
     changed_files = Ladle::ChangedFiles.new(build(:file_change, status: :added, file: 'one.rb', additions: 1),
                                             build(:file_change, status: :modified, file: 'sub/marine.rb', additions: 1, deletions: 1))
 
@@ -95,7 +95,7 @@ class PullRequestChangeCollectorTest < ActiveSupport::TestCase
     assert_deep_hash expected, Ladle::PullRequestChangeCollector.new(client).collect_changes(@pull_request)
   end
 
-  test 'notifies steward from same file across branches' do
+  test "collects changes for steward from same file across branches" do
     changed_files = Ladle::ChangedFiles.new(
       build(:file_change, status: :added, file: 'file1.txt', additions: 1),
       build(:file_change, status: :added, file: 'file2.txt', additions: 1),
@@ -146,7 +146,7 @@ class PullRequestChangeCollectorTest < ActiveSupport::TestCase
     assert_deep_hash expected, Ladle::PullRequestChangeCollector.new(client).collect_changes(@pull_request)
   end
 
-  test 'notifies old stewards' do
+  test 'collects old stewards' do
     changed_files = Ladle::ChangedFiles.new(
       build(:file_change, status: :removed, file: 'stewards.yml', deletions: 1),
       build(:file_change, status: :added, file: 'one.rb', additions: 1),
@@ -270,7 +270,7 @@ class PullRequestChangeCollectorTest < ActiveSupport::TestCase
     assert_deep_hash expected, Ladle::PullRequestChangeCollector.new(client).collect_changes(@pull_request)
   end
 
-  test 'notify - stewards file not in changes_view' do
+  test 'collects - stewards file not in changes_view' do
     changed_files = Ladle::ChangedFiles.new(
       build(:file_change, status: :added, file: 'goodbye/kitty/sianara.txt', additions: 1),
       build(:file_change, status: :added, file: 'hello/kitty/what/che.txt', additions: 1),
@@ -325,7 +325,7 @@ class PullRequestChangeCollectorTest < ActiveSupport::TestCase
     assert_deep_hash expected, Ladle::PullRequestChangeCollector.new(client).collect_changes(@pull_request)
   end
 
-  test 'handle handles invalid stewards files ' do
+  test 'collect_changes handles invalid stewards files ' do
     changed_files = Ladle::ChangedFiles.new(
       build(:file_change, status: :added, file: 'one.rb', additions: 1),
       build(:file_change, status: :modified, file: 'sub/marine.rb', additions: 1, deletions: 1)
@@ -364,7 +364,7 @@ class PullRequestChangeCollectorTest < ActiveSupport::TestCase
     assert_deep_hash expected, Ladle::PullRequestChangeCollector.new(client).collect_changes(@pull_request)
   end
 
-  test 'handle omits notifying of views/stewards without changes' do
+  test 'omits stewards without changes' do
     changed_files = Ladle::ChangedFiles.new(
       build(:file_change, status: :added, file: 'hello/kitty/what/is/your/favorite_food.yml', additions: 1),
       build(:file_change, status: :added, file: 'hello/kitty/what/is/your/name.txt', additions: 1)
@@ -424,8 +424,8 @@ class PullRequestChangeCollectorTest < ActiveSupport::TestCase
       build(:file_change, file: 'sub3/stewards.yml')
     )
 
-    handler = Ladle::PullRequestChangeCollector.new(mock('client'))
-    resolved_stewards_registry = handler.send(:append_changes, stewards_trees, changed_files)
+    collector = Ladle::PullRequestChangeCollector.new(mock('client'))
+    resolved_stewards_registry = collector.send(:append_changes, stewards_trees, changed_files)
 
     expected_changes_view = Ladle::ChangesView.new(
       {

--- a/test/ladle/steward_notifier_test.rb
+++ b/test/ladle/steward_notifier_test.rb
@@ -5,11 +5,7 @@ require 'ladle/test_data'
 
 class StewardNotifierTest < ActionController::TestCase
   setup do
-    @steward_changes_views = {
-      'xanderstrike' => Ladle::TestData.create_changes_view,
-      'counterstrike'=> Ladle::TestData.create_changes_view,
-      'boop'         => Ladle::TestData.create_changes_view
-    }
+    @steward_changes_views = Ladle::TestData.create_stewards_map
     @pull_request = create(:pull_request, html_url: 'https://github.com/XanderStrike/test/pull/11')
     @notifier = Ladle::StewardNotifier.new('XanderStrike/test', @pull_request)
   end

--- a/test/ladle/steward_notifier_test.rb
+++ b/test/ladle/steward_notifier_test.rb
@@ -10,7 +10,7 @@ class StewardNotifierTest < ActionController::TestCase
     @notifier = Ladle::StewardNotifier.new('XanderStrike/test', @pull_request)
   end
 
-  test 'assigns the handler' do
+  test 'assigns the pull request' do
     assert_equal @pull_request, @notifier.instance_variable_get(:@pull_request)
   end
 


### PR DESCRIPTION
Addresses #63:
- Changed `PullHandler` to return values instead of use a "notifier" collaborator.
- Renamed `PullHandler` to `PullRequestChangeCollector`.
- Extract `NotifyStewardsOfPullRequestChanges` from `GithubEventsController`.
- Create a `TestData.create_stewards_map` to be reused across unit tests to verify contracts.