### PR TITLE
Fix json gem and simple_form gem security vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,10 @@ gem 'jquery-rails'
 gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
+# Adding direct dependency to move to secure version
+gem 'json', '~> 2.3'
 # bundle exec rake doc:rails generates the API under doc/api.
-gem 'sdoc', '~> 0.4.0', group: :doc
+gem 'sdoc', '~> 1.1.0', group: :doc
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'omniauth-github'
 
 gem 'octokit', '~> 4.1'
 
-gem 'simple_form', '~> 3.2'
+gem 'simple_form', '~> 5.0'
 gem 'factory_bot_rails', '~> 4.0'
 
 # Use Capistrano for deployment

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.6)
+    json (2.3.0)
     jwt (2.2.1)
     loofah (2.4.0)
       crass (~> 1.0.2)
@@ -177,7 +177,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (4.3.0)
+    rdoc (6.2.1)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -197,9 +197,8 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    sdoc (0.4.2)
-      json (~> 1.7, >= 1.7.7)
-      rdoc (~> 4.0)
+    sdoc (1.1.0)
+      rdoc (>= 5.0)
     simple_form (5.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -260,6 +259,7 @@ DEPENDENCIES
   hashdiff (= 0.2.2)
   jbuilder (~> 2.0)
   jquery-rails
+  json (~> 2.3)
   minitest (= 5.10.3)
   mocha
   octokit (~> 4.1)
@@ -271,7 +271,7 @@ DEPENDENCIES
   rails_12factor
   rugged
   sass-rails (~> 5.0)
-  sdoc (~> 0.4.0)
+  sdoc (~> 1.1.0)
   simple_form (~> 5.0)
   spring
   turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,9 +200,9 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    simple_form (3.5.1)
-      actionpack (> 4, < 5.2)
-      activemodel (> 4, < 5.2)
+    simple_form (5.0.2)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -272,7 +272,7 @@ DEPENDENCIES
   rugged
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
-  simple_form (~> 3.2)
+  simple_form (~> 5.0)
   spring
   turbolinks
   uglifier (>= 1.3.0)


### PR DESCRIPTION
These errors were identified by SourceClear.  Update to safe versions.