### PR TITLE
ml - install cmake before installing rugged gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,10 @@ jobs:
           command: |
             bundle config gemini.atl.appfolio.net $GEMINI_USER:$GEMINI_PASSWORD
 
+      - run: # Install rugged/libgit2 dependencies
+          name: CMake Install
+          command: sudo apt-get install cmake
+
       - run:
           name: install dependencies
           command: |


### PR DESCRIPTION
CircleCI fails with this error:

An error occurred while installing rugged (0.28.4.1), and Bundler cannot continue.
 
Make sure that `gem install rugged -v '0.28.4.1' --source 'https://rubygems.org/'` succeeds before bundling.
 
Trying workaround noted here:
https://stackoverflow.com/questions/27472234/an-error-occurred-while-installing-rugged