### PR TITLE
Adding static code analysis orb to run Brakeman scans and reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
 version: 2.1
+orbs:
+  static-code-analysis: appfolio/static-code-analysis@volatile
+
 jobs:
   build-and-test:
     docker:
@@ -67,6 +70,22 @@ jobs:
 workflows:
   version: 2.1
   rc:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - build-and-test:
           context: appfolio_test_context
+  nightly-static-code-security-analysis:
+    # Configure trigger at https://app.circleci.com/settings/project/github/appfolio/ladle/triggers
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "Nightly static code security analysis", << pipeline.schedule.name >> ]
+    jobs:
+      - static-code-analysis/scan:
+          context: appfolio_static-code-analysis
+      - static-code-analysis/report:
+          context: appfolio_static-code-analysis
+          requires:
+            - static-code-analysis/scan


### PR DESCRIPTION
  This PR adds CircleCI jobs from an orb that the security team created that runs scans with Brakeman, a static code analysis tool that finds security issues in Ruby on Rails. For each new warning it finds, it does three things:

  1. Creates a GitHub issue in that repo with all of the information about that Brakeman warning. See [here](https://github.com/appfolio/newhire_app/issues/1233) for an example. Once an issue has been created for a warning, it won’t be recreated by a subsequent scan (as long as the fingerprint of the warning hasn’t changed).
  2. Sends a Slack alert to the security team telling us this new issue got created so we can investigate it.
  3. Adds that GitHub issue to a GitHub project that allows the security team to track open vulnerabilities.

  The confidence level of the Brakeman scan is configurable in the orb parameters, but it defaults to only “high” confidence issues for now.

  This PR has the orb running nightly as a scheduled pipeline on CircleCI. We use a scheduled pipeline since pipelines can be run as specific users, and we need to run the CircleCI job as a user who has access to the restricted context used by the orb. Once this PR is merged, I'll create the scheduled pipeline in CircleCI to run as the security team's machine user.
