### PR TITLE
[KNOW-141] Add software catalog metadata file(s)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  title: ladle
+  description: An application for assisting in Appfolio's implementation of code stewardship
+  tags:
+    - rails
+  annotations: {}
+  name: ladle
+spec:
+  type: service
+  lifecycle: deprecated
+  owner: mighty-dux


### PR DESCRIPTION
All Developer Portal component, resource, and api catalog metadata files are migrating to project repositories to lower the rate of effort for catalog maintenance. See [this Slack announcement](https://appfolio.slack.com/archives/C02A9D6U3/p1708547921002909).

[_Created by Sourcegraph batch change `modethirteen/migrate-developer-portal-catalog-metadata`._](https://sourcegraph.appf.io/users/modethirteen/batch-changes/migrate-developer-portal-catalog-metadata)